### PR TITLE
Allow tutorial overlay to be dismissed

### DIFF
--- a/game.js
+++ b/game.js
@@ -68,16 +68,21 @@ function showTutorial() {
     'Have fun serving pizzas!'
   ];
   let idx = 0;
-  tutorialBox.textContent = steps[idx];
+  tutorialBox.innerHTML = `<div id="tutorial-text">${steps[idx]}</div><button id="tutorial-next">Next</button>`;
   tutorialBox.classList.remove('hidden');
-  tutorialBox.addEventListener('click', next);
+  const text = document.getElementById('tutorial-text');
+  const btn = document.getElementById('tutorial-next');
+  btn.addEventListener('click', next);
   function next() {
     idx++;
     if (idx < steps.length) {
-      tutorialBox.textContent = steps[idx];
+      text.textContent = steps[idx];
+      if (idx === steps.length - 1) {
+        btn.textContent = 'Start';
+      }
     } else {
       tutorialBox.classList.add('hidden');
-      tutorialBox.removeEventListener('click', next);
+      btn.removeEventListener('click', next);
       state.tutorial = false;
       saveState();
       startPrep();

--- a/style.css
+++ b/style.css
@@ -44,6 +44,7 @@ button, input[type=number], input[type=range] {
   top: 0; left: 0; right:0; bottom:0;
   background: rgba(0,0,0,0.7);
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   color: white;


### PR DESCRIPTION
## Summary
- Add explicit Next/Start button to tutorial instructions so players can close it
- Stack tutorial text and button vertically with flex styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aab36c3948331a2aee83a17f08acc