### PR TITLE
Keep ingredient bar within mobile viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,6 +4,14 @@ html, body {
   font-family: 'Arial', sans-serif;
   background: #fff8e1;
   color: #333;
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  overflow-x: hidden;
 }
 
 #top-bar, #bottom-bar {
@@ -16,6 +24,11 @@ html, body {
   font-size: 18px;
 }
 
+#bottom-bar {
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 #top-bar a {
   color: white;
 }
@@ -23,6 +36,8 @@ html, body {
 #center {
   padding: 10px;
   text-align: center;
+  flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 button, input[type=number], input[type=range] {


### PR DESCRIPTION
## Summary
- Convert page layout to a flex column to keep top and bottom bars inside the mobile viewport and prevent horizontal overflow
- Allow the ingredient bar to wrap and center its contents so all ingredients stay visible on small screens
- Make the center area flexible and scrollable to fit within the remaining space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ab14e8a58833194c63dd6f95ae63d