### PR TITLE
Add looping background music and improve ingredient ordering UI

### DIFF
--- a/game.js
+++ b/game.js
@@ -31,6 +31,10 @@ const center = document.getElementById('center');
 const bottom = document.getElementById('bottom-bar');
 const dashboardBox = document.getElementById('dashboard');
 const menuBtn = document.getElementById('menu-btn');
+const bgMusic = document.getElementById('bg-music');
+if (state.settings.audio) {
+  bgMusic.play().catch(() => {});
+}
 
 menuBtn.addEventListener('click', () => {
   dashboardBox.classList.toggle('hidden');
@@ -80,6 +84,7 @@ function startPrep() {
     const cost = config.unitCost[k];
     const label = document.createElement('label');
     label.textContent = `${k} ($${cost})`;
+    label.style.display = 'block';
     const inp = document.createElement('input');
     inp.type = 'number'; inp.min = 0; inp.value = 0; inp.style.width='60px';
     inputs[k]=inp;

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <div id="center"></div>
   <div id="bottom-bar"></div>
   <div id="dashboard" class="hidden"></div>
+  <audio id="bg-music" src="italian-cafe-background-music-372616.mp3" loop></audio>
 
   <script src="game.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- Show each ingredient input on its own line when ordering inventory
- Play looping Italian cafe background music on app launch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ab4ff65bc833197e3274257a8e267