### PR TITLE
Enlarge bake button image on assembly grid

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,3 +102,8 @@ button, input[type=number], input[type=range] {
 #assembly-grid .bake-btn {
   grid-row: 1 / span 2;
 }
+
+#assembly-grid .bake-btn img {
+  width: 120px;
+  height: 120px;
+}


### PR DESCRIPTION
## Summary
- double the bake and serve button image size so it spans both grid rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689acad54a14833189e1abea85b63608