### PR TITLE
Display topping images for customer orders

### DIFF
--- a/game.js
+++ b/game.js
@@ -224,9 +224,29 @@ function startService(demand){
   function renderCustomers(){
     custDiv.innerHTML='';
     serviceData.customers.forEach(c=>{
-      const div=document.createElement('div'); div.className='customer';
-      const toppingText=c.toppings.length?c.toppings.join(','):'plain';
-      div.innerHTML=`Customer wants: ${toppingText} <div id="wait-${c.id}">😀</div>`;
+      const div=document.createElement('div');
+      div.className='customer';
+
+      const label=document.createElement('span');
+      label.textContent='Customer wants: ';
+      div.appendChild(label);
+
+      const orderSpan=document.createElement('span');
+      const toppings=c.toppings.length ? c.toppings : ['cheese'];
+      toppings.forEach(t=>{
+        const img=document.createElement('img');
+        img.src=`img/${t}.png`;
+        img.alt=t;
+        img.className='order-icon';
+        orderSpan.appendChild(img);
+      });
+      div.appendChild(orderSpan);
+
+      const wait=document.createElement('div');
+      wait.id=`wait-${c.id}`;
+      wait.textContent='😀';
+      div.appendChild(wait);
+
       custDiv.appendChild(div);
     });
   }

--- a/style.css
+++ b/style.css
@@ -56,6 +56,13 @@ button, input[type=number], input[type=range] {
   margin: 6px;
 }
 
+.order-icon {
+  width: 40px;
+  height: 40px;
+  margin: 0 2px;
+  vertical-align: middle;
+}
+
 .hidden { display: none; }
 
 #dashboard {


### PR DESCRIPTION
## Summary
- Render customer orders with topping images instead of text
- Add styling for order icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a15df4df488331a1ff9bbf68dcb361